### PR TITLE
Fix input zoom on iOS

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,6 +50,14 @@ ul {
   }
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) { 
+  select,
+  textarea,
+  input {
+    font-size: 16px;
+  }
+}
+
 .headphones {
   height: 1rem;
 }


### PR DESCRIPTION
When using iOS, if you tap on the search box, the webpage zooms in. This fixes that by setting the font-size explicitly. Ultimately a very minor issue, but does effect on UX, as the user now has to pinch and zoom out to view the end of text boxes.